### PR TITLE
✨ [FEAT/#25] 초기화면 누적 앨범·축하글 수 조회 구현

### DIFF
--- a/src/main/java/com/example/graduate/domain/album/service/AlbumService.java
+++ b/src/main/java/com/example/graduate/domain/album/service/AlbumService.java
@@ -9,8 +9,10 @@ import com.example.graduate.domain.user.repository.UserRepository;
 import com.example.graduate.global.SecurityUtil;
 import com.example.graduate.global.apiPayload.exception.GeneralException;
 import com.example.graduate.domain.album.status.AlbumErrorStatus;
+import com.example.graduate.global.redis.RedisUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,12 +22,14 @@ public class AlbumService {
     private final AlbumRepository albumRepository;
     private final UserRepository userRepository;
     private final SecurityUtil securityUtil;
+    private final RedisUtil redisUtil;
 
     private Long getCurrentUserId() {
         User user = securityUtil.getCurrentUser();
         return user.getId();
     }
-
+    
+    @Transactional
     public AlbumResponseDTO createAlbum(AlbumRequestDTO dto) {
         Long userId = getCurrentUserId();
 
@@ -45,6 +49,8 @@ public class AlbumService {
                 .build();
 
         albumRepository.save(album);
+        redisUtil.increment("project:album:count");
+
         return AlbumResponseDTO.builder()
                 .id(album.getId())
                 .albumName(album.getAlbumName())

--- a/src/main/java/com/example/graduate/domain/letter/service/LetterService.java
+++ b/src/main/java/com/example/graduate/domain/letter/service/LetterService.java
@@ -13,6 +13,7 @@ import com.example.graduate.domain.letter.domain.letterStatus.LetterErrorStatus;
 import com.example.graduate.global.aws.s3.AmazonS3Manager;
 import com.example.graduate.global.aws.s3.Uuid;
 import com.example.graduate.global.aws.s3.UuidRepository;
+import com.example.graduate.global.redis.RedisUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.annotation.Id;
@@ -31,6 +32,7 @@ public class LetterService {
     private final LetterRepository letterRepository;
     private final AlbumRepository albumRepository;
     private final SecurityUtil securityUtil;
+    private final RedisUtil redisUtil;
 
     //s3 관련 코드 추가
     private final AmazonS3Manager amazonS3Manager;
@@ -71,6 +73,7 @@ public class LetterService {
                 .userId(userId)
                 .build();
         letterRepository.save(letter);
+        redisUtil.increment("project:letter:count");
     }
 
     //축하글 수정

--- a/src/main/java/com/example/graduate/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/example/graduate/domain/project/controller/ProjectController.java
@@ -1,7 +1,8 @@
 package com.example.graduate.domain.project.controller;
 
-import com.example.graduate.domain.project.dto.response.ProjectResponse;
+import com.example.graduate.domain.project.dto.response.ProjectResponseDTO;
 import com.example.graduate.domain.project.service.ProjectService;
+import com.example.graduate.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,9 @@ public class ProjectController {
       summary = "누적 앨범·축하글 수 조회",
       description = "현재까지 생성된 앨범·축하글 수를 조회합니다.")
   @GetMapping("/info")
-  public ResponseEntity<ProjectResponse> getProjectSummary() {
-    return ResponseEntity.ok(projectService.getSummary());
+  public ResponseEntity<ApiResponse<ProjectResponseDTO>> getProjectSummary() {
+    ProjectResponseDTO result = projectService.getSummary();
+
+    return ResponseEntity.ok(ApiResponse.onSuccess(result));
   }
 }

--- a/src/main/java/com/example/graduate/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/example/graduate/domain/project/controller/ProjectController.java
@@ -1,0 +1,22 @@
+package com.example.graduate.domain.project.controller;
+
+import com.example.graduate.domain.project.dto.response.ProjectResponse;
+import com.example.graduate.domain.project.service.ProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/project")
+public class ProjectController {
+
+  private final ProjectService projectService;
+
+  @GetMapping("/info")
+  public ResponseEntity<ProjectResponse> getProjectSummary() {
+    return ResponseEntity.ok(projectService.getSummary());
+  }
+}

--- a/src/main/java/com/example/graduate/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/example/graduate/domain/project/controller/ProjectController.java
@@ -2,6 +2,8 @@ package com.example.graduate.domain.project.controller;
 
 import com.example.graduate.domain.project.dto.response.ProjectResponse;
 import com.example.graduate.domain.project.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,10 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/project")
+@Tag(name = "프로젝트 정보 관련 API", description = "프로젝트의 정보에 관련된 기능을 제공합니다.")
 public class ProjectController {
 
   private final ProjectService projectService;
 
+  @Operation(
+      summary = "누적 앨범·축하글 수 조회",
+      description = "현재까지 생성된 앨범·축하글 수를 조회합니다.")
   @GetMapping("/info")
   public ResponseEntity<ProjectResponse> getProjectSummary() {
     return ResponseEntity.ok(projectService.getSummary());

--- a/src/main/java/com/example/graduate/domain/project/dto/response/ProjectResponse.java
+++ b/src/main/java/com/example/graduate/domain/project/dto/response/ProjectResponse.java
@@ -1,0 +1,12 @@
+package com.example.graduate.domain.project.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProjectResponse {
+  private final long totalAlbumCount;
+  private final long totalLetterCount;
+}

--- a/src/main/java/com/example/graduate/domain/project/dto/response/ProjectResponseDTO.java
+++ b/src/main/java/com/example/graduate/domain/project/dto/response/ProjectResponseDTO.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ProjectResponse {
+public class ProjectResponseDTO {
   private final long totalAlbumCount;
   private final long totalLetterCount;
 }

--- a/src/main/java/com/example/graduate/domain/project/service/ProjectService.java
+++ b/src/main/java/com/example/graduate/domain/project/service/ProjectService.java
@@ -1,7 +1,7 @@
 package com.example.graduate.domain.project.service;
 
 
-import com.example.graduate.domain.project.dto.response.ProjectResponse;
+import com.example.graduate.domain.project.dto.response.ProjectResponseDTO;
 import com.example.graduate.global.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,11 +15,11 @@ public class ProjectService {
   private static final String ALBUM_COUNT_KEY = "project:album:count";
   private static final String LETTER_COUNT_KEY = "project:letter:count";
 
-  public ProjectResponse getSummary() {
+  public ProjectResponseDTO getSummary() {
 
     long albumCount = redisUtil.getLongValue(ALBUM_COUNT_KEY);
     long letterCount = redisUtil.getLongValue(LETTER_COUNT_KEY);
 
-    return new ProjectResponse(albumCount, letterCount);
+    return new ProjectResponseDTO(albumCount, letterCount);
   }
 }

--- a/src/main/java/com/example/graduate/domain/project/service/ProjectService.java
+++ b/src/main/java/com/example/graduate/domain/project/service/ProjectService.java
@@ -1,0 +1,25 @@
+package com.example.graduate.domain.project.service;
+
+
+import com.example.graduate.domain.project.dto.response.ProjectResponse;
+import com.example.graduate.global.redis.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectService {
+
+  private final RedisUtil redisUtil;
+
+  private static final String ALBUM_COUNT_KEY = "project:album:count";
+  private static final String LETTER_COUNT_KEY = "project:letter:count";
+
+  public ProjectResponse getSummary() {
+
+    long albumCount = redisUtil.getLongValue(ALBUM_COUNT_KEY);
+    long letterCount = redisUtil.getLongValue(LETTER_COUNT_KEY);
+
+    return new ProjectResponse(albumCount, letterCount);
+  }
+}

--- a/src/main/java/com/example/graduate/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/graduate/global/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/test/permit-all").permitAll()
                         .requestMatchers("/api/albums/**").permitAll()
                         .requestMatchers("/api/auth/kakao/**").permitAll()
+                        .requestMatchers("/api/project/**").permitAll()
                         .anyRequest().authenticated())
 
             .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/graduate/global/redis/RedisUtil.java
+++ b/src/main/java/com/example/graduate/global/redis/RedisUtil.java
@@ -40,4 +40,20 @@ public class RedisUtil {
     public void deleteData(String key) {
         template.delete(key);
     }
+
+    //데이터 증가
+    public Long increment(String key) {
+        return template.opsForValue().increment(key);
+    }
+
+    //데이터 감소
+    public Long decrement(String key) {
+        return template.opsForValue().decrement(key);
+    }
+
+    //데이터(숫자) 가져오기
+    public long getLongValue(String key) {
+        String value = getData(key);
+        return value != null ? Long.parseLong(value) : 0L;
+    }
 }


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #25 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 초기화면에서 필요한 프로젝트 정보인 [누적 앨범 수, 누적 축하글 수]를 조회하는 API입니다.
- API 호출시에 누적 앨범 수와 축하글 수를 Redis에서 조회해옵니다.
- 앨범과 축하글 create시에 Redis에서 값을 증가해주는 로직을 추가하였습니다.


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->


## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->
