### PR TITLE
✨ [FEAT/#19] 회원 탈퇴 시 카카오 연결 해제 및 앨범 삭제 기능 추가

### DIFF
--- a/src/main/java/com/example/graduate/domain/album/service/AlbumService.java
+++ b/src/main/java/com/example/graduate/domain/album/service/AlbumService.java
@@ -4,6 +4,7 @@ import com.example.graduate.domain.album.domain.Album;
 import com.example.graduate.domain.album.dto.AlbumRequestDTO;
 import com.example.graduate.domain.album.dto.AlbumResponseDTO;
 import com.example.graduate.domain.album.repository.AlbumRepository;
+import com.example.graduate.domain.letter.repository.LetterRepository;
 import com.example.graduate.domain.user.entity.User;
 import com.example.graduate.domain.user.repository.UserRepository;
 import com.example.graduate.global.SecurityUtil;
@@ -21,6 +22,7 @@ public class AlbumService {
 
     private final AlbumRepository albumRepository;
     private final UserRepository userRepository;
+    private final LetterRepository letterRepository;
     private final SecurityUtil securityUtil;
     private final RedisUtil redisUtil;
 
@@ -81,6 +83,8 @@ public class AlbumService {
 
         Album album = albumRepository.findByUserId(userId)
                 .orElseThrow(() -> new GeneralException(AlbumErrorStatus._ALBUM_NOT_FOUND));
+        // 연관된 축하글 삭제
+        letterRepository.deleteAllByAlbumId(album.getId());
         albumRepository.delete(album);
     }
 

--- a/src/main/java/com/example/graduate/domain/letter/repository/LetterRepository.java
+++ b/src/main/java/com/example/graduate/domain/letter/repository/LetterRepository.java
@@ -28,6 +28,9 @@ public interface LetterRepository extends JpaRepository<Letter, Long> {
             Pageable pageable
     );
 
+
+    void deleteAllByAlbumId(Long albumId);
+
     default List<Letter> findTopByOrderByUpdatedAtDesc(int limit) {
         return findTopByOrderByUpdatedAtDesc(PageRequest.of(0, limit));
     }

--- a/src/main/java/com/example/graduate/domain/user/exception/UserErrorStatus.java
+++ b/src/main/java/com/example/graduate/domain/user/exception/UserErrorStatus.java
@@ -19,6 +19,8 @@ public enum UserErrorStatus implements BaseErrorCode {
   TOKEN_EXPIRED("AUTH4008", "리프레시 토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
   TOKEN_FAIL("AUTH4009", "토큰 파싱 또는 추출에 실패했습니다.", HttpStatus.BAD_REQUEST),
   INVALID_AUTHENTICATION("AUTH4010", "인증 정보가 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
+
+  UNLINK_FAILED("USER4011", "카카오 연결 해제에 실패했습니다.", HttpStatus.BAD_REQUEST),
   ;
 
   private final String code;

--- a/src/main/java/com/example/graduate/domain/user/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/graduate/domain/user/service/KakaoOAuthService.java
@@ -22,9 +22,6 @@ public class KakaoOAuthService {
   private final KakaoOAuthProperties props;
   private final RestTemplate restTemplate;
 
-  @Value("${kakao.admin-key}")
-  private String kakaoAdminKey;
-
   /**
    * 카카오 인가 URI 생성
    */
@@ -85,7 +82,7 @@ public class KakaoOAuthService {
 
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-    headers.set("Authorization", "KakaoAK " + kakaoAdminKey);
+    headers.set("Authorization", "KakaoAK " + props.getAdminKey());
 
     MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
     body.add("target_id_type", "user_id");

--- a/src/main/java/com/example/graduate/domain/user/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/graduate/domain/user/service/KakaoOAuthService.java
@@ -5,6 +5,7 @@ import com.example.graduate.global.config.KakaoOAuthProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -20,6 +21,9 @@ import org.springframework.web.client.RestTemplate;
 public class KakaoOAuthService {
   private final KakaoOAuthProperties props;
   private final RestTemplate restTemplate;
+
+  @Value("${kakao.admin-key}")
+  private String kakaoAdminKey;
 
   /**
    * 카카오 인가 URI 생성
@@ -74,5 +78,20 @@ public class KakaoOAuthService {
     String email = body.get("kakao_account").get("email").asText();
 
     return new KakaoUserInfo(id, name, email);
+  }
+
+  public void unlinkKakao(String socialId) {
+    String url = "https://kapi.kakao.com/v1/user/unlink";
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    headers.set("Authorization", "KakaoAK " + kakaoAdminKey);
+
+    MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+    body.add("target_id_type", "user_id");
+    body.add("target_id", socialId);
+
+    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+    restTemplate.postForEntity(url, request, String.class);
   }
 }

--- a/src/main/java/com/example/graduate/domain/user/service/UserService.java
+++ b/src/main/java/com/example/graduate/domain/user/service/UserService.java
@@ -26,6 +26,7 @@ public class UserService {
   private final JwtUtil jwtUtil;
   private final RedisUtil redisUtil;
   private final SecurityUtil securityUtil;
+  private final KakaoOAuthService kakaoOAuthService;
 
   @Value("${cookie.secure}")
   private boolean secureCookie;
@@ -188,6 +189,13 @@ public class UserService {
       HttpServletResponse response) {
     User user = securityUtil.getCurrentUser();
     String socialId = user.getSocialId();
+
+    // 카카오 연결 해제
+    try {
+      kakaoOAuthService.unlinkKakao(socialId);
+    } catch (Exception e) {
+      throw new GeneralException(UserErrorStatus.UNLINK_FAILED);
+    }
 
     userRepository.delete(user);
     redisUtil.deleteData("refresh:" + socialId);

--- a/src/main/java/com/example/graduate/domain/user/service/UserService.java
+++ b/src/main/java/com/example/graduate/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.graduate.domain.user.service;
 
+import com.example.graduate.domain.album.service.AlbumService;
 import com.example.graduate.domain.user.dto.request.KakaoUserInfo;
 import com.example.graduate.domain.user.entity.User;
 import com.example.graduate.domain.user.exception.UserErrorStatus;
@@ -22,6 +23,7 @@ import com.example.graduate.global.redis.RedisUtil;
 @RequiredArgsConstructor
 public class UserService {
   private final UserRepository userRepository;
+  private final AlbumService albumService;
   private final UserMapper userMapper;
   private final JwtUtil jwtUtil;
   private final RedisUtil redisUtil;
@@ -197,6 +199,8 @@ public class UserService {
       throw new GeneralException(UserErrorStatus.UNLINK_FAILED);
     }
 
+    // 사용자 로그인 정보를 사용하여 앨범 삭제 (사용자 삭제보다 먼저 호출)
+    albumService.deleteAlbum();
     userRepository.delete(user);
     redisUtil.deleteData("refresh:" + socialId);
 

--- a/src/main/java/com/example/graduate/global/config/KakaoOAuthProperties.java
+++ b/src/main/java/com/example/graduate/global/config/KakaoOAuthProperties.java
@@ -13,4 +13,5 @@ public class KakaoOAuthProperties {
   private String redirectUri;
   private String tokenUri;
   private String userInfoUri;
+  private String adminKey;
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -46,6 +46,7 @@ oauth:
     redirect-uri: ${KAKAO_REDIRECT_URI}
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
+    admin-key: ${KAKAO_ADMIN_KEY}
 
 cookie:
   secure: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -62,6 +62,7 @@ oauth:
     redirect-uri: ${KAKAO_REDIRECT_URI}
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
+    admin-key: ${KAKAO_ADMIN_KEY}
 
 cookie:
   secure: true


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #19 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 회원 탈퇴 시 카카오 연결 해제 로직 추가
  - 회원탈퇴 200 응답 받은 뒤에, 카카오로 동일 socialId로 연결 해제 API 호출하면 "NotRegisteredUserException"가 뜨는걸로 보아 연결 해제가 잘 되었다고 판단했습니다.
- 회원 탈퇴 시 사용자 앨범 삭제 처리 추가
  - 앨범 삭제 시 연관된 축하글 삭제 로직 추가하였고, 회원 탈퇴 시 사용자 앨범 삭제 로직도 추가해주었습니다. DB에서 사용자 삭제 로직보다 먼저 실행하여 사용자 로그인 정보를 조회할 수 있게 하였습니다.

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
환경변수 값 추가 있습니다~~!! .env 파일에 값 추가해주세요! 

## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->
