### PR TITLE
:recycle: Cross-Domain 쿠키 미전송 이슈 해결을 위한 쿠키 생성 로직 보완

### DIFF
--- a/src/main/java/com/example/graduate/domain/user/service/UserService.java
+++ b/src/main/java/com/example/graduate/domain/user/service/UserService.java
@@ -138,18 +138,19 @@ public class UserService {
    * @param maxAge  쿠키 유효 기간 (초 단위)
    * @return 생성된 ResponseCookie
    */
-  private ResponseCookie createCookie(String key, String value, long maxAge, boolean secureCookie) {
+  private ResponseCookie createCookie(String key, String value, long maxAge) {
     ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(key, value)
         .httpOnly(true)
         .secure(secureCookie)
         .path("/")
         .maxAge(maxAge);
 
-    // prod일 때만 크로스 도메인 문제 해결
+    // prod 환경이면 SameSite + domain 설정 추가
     if (secureCookie) {
       builder.domain("photory.site");
       builder.sameSite("None");
     }
+
     return builder.build();
   }
 

--- a/src/main/java/com/example/graduate/domain/user/service/UserService.java
+++ b/src/main/java/com/example/graduate/domain/user/service/UserService.java
@@ -138,13 +138,19 @@ public class UserService {
    * @param maxAge  쿠키 유효 기간 (초 단위)
    * @return 생성된 ResponseCookie
    */
-  private ResponseCookie createCookie(String key, String value, long maxAge) {
-    return ResponseCookie.from(key, value)
+  private ResponseCookie createCookie(String key, String value, long maxAge, boolean secureCookie) {
+    ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(key, value)
         .httpOnly(true)
         .secure(secureCookie)
         .path("/")
-        .maxAge(maxAge)
-        .build();
+        .maxAge(maxAge);
+
+    // prod일 때만 크로스 도메인 문제 해결
+    if (secureCookie) {
+      builder.domain("photory.site");
+      builder.sameSite("None");
+    }
+    return builder.build();
   }
 
   /**


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #34 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- ResponseCookie 생성 시 secureCookie 값에 따라 SameSite와 Domain을 조건부로 설정하도록 수정
    - secureCookie=true일 경우: SameSite=None, domain=photory.site로 설정하여 크로스 도메인 쿠키 허용 
    - secureCookie=false일 경우: 로컬 개발 환경을 위해 domain 미설정
- 프론트 도메인(photory.site) 기준으로 쿠키 설정하여 브라우저가 토큰 쿠키를 저장/전송 가능하도록 처리


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
로그인, 토큰 재발급, 로그아웃, 엑세스 토큰 발급 등 쿠키를 생성하거나 삭제하는 로직에 이 설정이 반영됩니다!

## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->
