### PR TITLE
🐛 [BUG/#45] 회원 탈퇴 처리 중 오류 해결

### DIFF
--- a/src/main/java/com/example/graduate/domain/album/service/AlbumService.java
+++ b/src/main/java/com/example/graduate/domain/album/service/AlbumService.java
@@ -91,6 +91,16 @@ public class AlbumService {
         albumRepository.delete(album);
     }
 
+    @Transactional
+    public void deleteAlbumIfExists() {
+        Long userId = getCurrentUserId();
+
+        albumRepository.findByUserId(userId).ifPresent(album -> {
+            letterRepository.deleteAllByAlbumId(album.getId());
+            albumRepository.delete(album);
+        });
+    }
+
     public AlbumResponseDTO getAlbum() {
         Long userId = getCurrentUserId();
 

--- a/src/main/java/com/example/graduate/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/graduate/domain/user/controller/AuthController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,7 +46,7 @@ public class AuthController {
   @Operation(
       summary = "회원 탈퇴",
       description = "회원 탈퇴 처리 후 토큰 및 쿠키를 삭제합니다.")
-  @PostMapping("/delete")
+  @PostMapping(value = "/delete")
   public ApiResponse<Void> delete(HttpServletResponse response) {
     userService.delete(response);
 

--- a/src/main/java/com/example/graduate/domain/user/service/UserService.java
+++ b/src/main/java/com/example/graduate/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.example.graduate.domain.user.service;
 
+import static org.hibernate.query.sqm.tree.SqmNode.log;
+
 import com.example.graduate.domain.album.service.AlbumService;
 import com.example.graduate.domain.user.dto.request.KakaoUserInfo;
 import com.example.graduate.domain.user.entity.User;
@@ -14,12 +16,15 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import com.example.graduate.global.redis.RedisUtil;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class UserService {
   private final UserRepository userRepository;
@@ -190,24 +195,35 @@ public class UserService {
   }
 
   /**
-   * 회원 탈퇴 처리: 사용자 정보를 삭제하고 RefreshToken을 제거합니다.
+   * 회원 탈퇴 처리
    *
-   * @param response 클라이언트에 만료된 refreshToken 쿠키를 전달하여 삭제 처리
+   * @param response 만료된 refreshToken 쿠키를 추가하기 위한 HTTP 응답 객체
+   * @throws GeneralException 카카오 연결 해제에 실패(이미 해제된 경우 제외)한 경우
    */
-  public void delete(
-      HttpServletResponse response) {
+  public void delete(HttpServletResponse response) {
     User user = securityUtil.getCurrentUser();
     String socialId = user.getSocialId();
 
     // 카카오 연결 해제
     try {
       kakaoOAuthService.unlinkKakao(socialId);
-    } catch (Exception e) {
-      throw new GeneralException(UserErrorStatus.UNLINK_FAILED);
+    } catch (HttpClientErrorException e) {
+      String body = e.getResponseBodyAsString();
+      int status = e.getStatusCode().value();
+      log.warn("Kakao unlink failed: status={}, body={}", status, body);
+
+      // 이미 해제/미등록 사용자 멱등 처리
+      if (!(status == 400 && body != null &&
+          (body.contains("NotRegisteredUser") ||
+              body.contains("already") ||
+              body.contains("unlinked")))) {
+        throw new GeneralException(UserErrorStatus.UNLINK_FAILED);
+      }
+      log.info("Kakao already unlinked. Proceed.");
     }
 
     // 사용자 로그인 정보를 사용하여 앨범 삭제 (사용자 삭제보다 먼저 호출)
-    albumService.deleteAlbum();
+    albumService.deleteAlbumIfExists();
     userRepository.delete(user);
     redisUtil.deleteData("refresh:" + socialId);
 


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #45 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- "회원 탈퇴 처리 중 오류: 서버 오류: 404 - 앨범을 찾을 수 없습니다." 오류 해결을 위해 앨범이 없을 때도 탈퇴를 진행할 수 있도록 보완하였습니다.
- 카카오 계정이 이미 연결 해제되었거나(혹은 등록된 적이 없는 경우) 같은 요청이 여러 번 와도(중복 요청) 에러로 처리하지 않고 그냥 넘어가도록 처리했습니다.


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->


## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->
